### PR TITLE
build: support node.js >= 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
+  - "0.8"
   - "0.10"
+before_install:
+  # remove build script deps before install
+  - node -pe 'f="./package.json";p=require(f);d=p.devDependencies;for(k in d){if("co"===k.substr(0,2))delete d[k]}require("fs").writeFileSync(f,JSON.stringify(p,null,2))'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "mocha": "1",
     "should": "3"
   },
+  "engines": {
+    "node": ">= 0.8.0"
+  },
   "scripts": {
     "test": "make test"
   }


### PR DESCRIPTION
This module doesn't do anything special, so it should support node.js 0.8 "officially" by building on it in Travis CI. `cogent`, at least, uses the newer caret-style for a dependency, so doesn't want to install on node.js 08. on Travis CI :(

If cogent doesn't want to change, since this is just required for the build.js script and not to test, I made Travis CI ignore the co\* devDependencies so it can test on node.js 0.8?

What do you guys think about including this commit? I would love to be able to not support node.js 0.8...
