### PR TITLE
Set utf-8 for application/javascript by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ exports.charset = function (type) {
   // special cases
   switch (type) {
     case 'application/json': return 'UTF-8'
+    case 'application/javascript': return 'UTF-8'
   }
 
   // default text/* to utf-8


### PR DESCRIPTION
This seems sane, cause `application/json` gets utf-8, `text/*` get utf-8 too.

For practical use, if JS comes without encoding, developer tools in chrome show crap instead of non-ASCII symbols.

If there are no problems (are there any?) I'd suggest to add utf-8 to .js too by default.
