### PR TITLE
support filepaths to .contentType()

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ mime.lookup('cats') // false
 
 ### mime.contentType(type)
 
-Create a full content-type header given a content-type or extension.
+Create a full content-type header given a content-type, extension, or file path.
 
 ```js
 mime.contentType('markdown')  // 'text/x-markdown; charset=utf-8'
-mime.contentType('file.json') // 'application/json; charset=utf-8'
+mime.contentType('path/to/file.json') // 'application/json; charset=utf-8'
 ```
 
 ### mime.extension(type)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ mime.lookup('cats') // false
 
 ### mime.contentType(type)
 
-Create a full content-type header given a content-type, extension, or file path.
+Create a full content-type header given an extension or file path.
 
 ```js
 mime.contentType('markdown')  // 'text/x-markdown; charset=utf-8'

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ exports.charsets = {
 // to do: maybe use set-type module or something
 exports.contentType = function (type) {
   if (!type || typeof type !== "string") return false
-  if (!~type.indexOf('/')) type = exports.lookup(type)
+  if (!~type.indexOf(';')) type = exports.lookup(type)
   if (!type) return false
   if (!~type.indexOf('charset')) {
     var charset = exports.charset(type)

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ exports.charsets = {
 // to do: maybe use set-type module or something
 exports.contentType = function (type) {
   if (!type || typeof type !== "string") return false
-  if (!~type.indexOf(';')) type = exports.lookup(type)
+  type = exports.lookup(type)
   if (!type) return false
   if (!~type.indexOf('charset')) {
     var charset = exports.charset(type)

--- a/test/test.js
+++ b/test/test.js
@@ -89,6 +89,10 @@ describe('.contentType()', function () {
     assert.equal(contentType('jade'), 'text/jade; charset=utf-8')
   })
 
+  it('path/to/a/file.json', function () {
+    assert.equal(contentType('path/to/a/file.json'), 'application/json; charset=utf-8')
+  });
+
   it('should not error on non-string types', function () {
     assert.doesNotThrow(function () {
       contentType({ noteven: "once" })

--- a/test/test.js
+++ b/test/test.js
@@ -73,8 +73,8 @@ describe('.contentType()', function () {
     assert.equal(contentType('html'), 'text/html; charset=utf-8')
   })
 
-  it('text/html; charset=ascii', function () {
-    assert.equal(contentType('text/html; charset=ascii'), 'text/html; charset=ascii')
+  it('file;name.html', function () {
+    assert.equal(contentType('file;name.html'), 'text/html; charset=utf-8')
   })
 
   it('json', function () {
@@ -91,7 +91,7 @@ describe('.contentType()', function () {
 
   it('path/to/a/file.json', function () {
     assert.equal(contentType('path/to/a/file.json'), 'application/json; charset=utf-8')
-  });
+  })
 
   it('should not error on non-string types', function () {
     assert.doesNotThrow(function () {


### PR DESCRIPTION
I noticed the readme makes it seem as though file paths will please the .contentType() method, but when used with a path like "here/is/my/file.json", the directory separator `/` is being mistaken for a content-type's `/`, which is interpreted as "I don't need you to lookup the content-type". Instead of looking for a `/`, I changed it look for a `;`. Hope this isn't a terrible solution!