### PR TITLE
Add 'glob' function to expand mime patterns.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,3 +61,21 @@ exports.contentType = function (type) {
   }
   return type
 }
+
+exports.glob = function (pattern) {
+  if (!pattern || typeof pattern !== "string") return false
+  if (pattern == '*/*')
+    return ["application/octet-stream"]
+
+  var slashIdx = pattern.indexOf("/")
+  if (slashIdx == -1 || pattern.slice(slashIdx + 1) !== "*")
+    return [pattern]
+
+  var prefix = pattern.slice(0,slashIdx+1);
+  var result = []
+  Object.keys(db).forEach(function (name) {
+    if (name.slice(0, slashIdx+1) === prefix)
+      result.push(name)
+  })
+  return result
+}


### PR DESCRIPTION
In my project I needed to expand patterns like this: `"*/*"`, `"video/*"`, `"audio/*"` into list of MIME types, because they were used in Google Discovery API.
If accepted I will add tests and documentation.