### PR TITLE
Added TypeScript Definition File

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,46 @@
+/**
+ * Get the default charset for a MIME type.
+ *
+ * @param {string} mimeType MIME type
+ * @return {string|boolean} the default charset or false if not found
+ */
+export function charset (mimeType: string): string
+
+/**
+ * Create a full Content-Type header given a MIME type or extension.
+ *
+ * @param {string} type MIME type or extension
+ * @return {boolean|string} Content-Type header
+ */
+export function contentType (type: string): string
+
+/**
+ * Get the default extension for a MIME type.
+ *
+ * @param {string} mimeType MIME type
+ * @return {boolean|string} the extension or false if not found
+ */
+export function extension (mimeType: string): string
+
+/**
+ * Lookup the MIME type for a file path/extension.
+ *
+ * @param {string} path
+ * @return {string|boolean} MIME type, or false if not found
+ */
+export function lookup (path: string): string
+
+/**
+ * charsets.lookup redirects to lookup
+ */
+export var charsets: {lookup: (mimeType: string) => string}
+
+/**
+ * File extensions indexed by MIME type
+ */
+export var extensions: { [extension: string]: string };
+
+/**
+ * MIME types indexed by (lower case) file extension
+ */
+export var types: { [contentType: string]: string };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "files": [
     "HISTORY.md",
     "LICENSE",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "engines": {
     "node": ">= 0.6"


### PR DESCRIPTION
I used the following test TypeScirpt to test the TypeScript definitions:
```javascript
/**
 * Sample & test importing NPM module "mime-types" in TypeScript
 */

import * as mimeTypes from "mime-types"
import * as assert from "assert"

assert.equal(mimeTypes.charset('application/json'), 'UTF-8');
assert.equal(mimeTypes.charset('application/json; foo=bar'), 'UTF-8');
assert.equal(mimeTypes.charset('application/javascript'), 'UTF-8');
assert.equal(mimeTypes.charset('text/html'), 'UTF-8');
assert.equal(mimeTypes.charset('TEXT/HTML'), 'UTF-8');
assert.strictEqual(mimeTypes.charset('application/x-bogus'), false);
assert.equal(mimeTypes.contentType('html'), 'text/html; charset=utf-8');
assert.equal(mimeTypes.contentType('text/html; charset=iso-8859-1'), 'text/html; charset=iso-8859-1');

assert.equal(mimeTypes.charsets.lookup('application/javascript'), 'UTF-8');
assert.deepEqual(mimeTypes.extensions['application/javascript'], ['js']);
assert.equal(mimeTypes.types['js'], 'application/javascript');

console.log('Works!!!');
```