### PR TITLE
Add in new public function - lookupAll().

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ mime.lookup('folder/.htaccess') // false
 mime.lookup('cats') // false
 ```
 
+### mime.lookupAll(path)
+
+Find all MIME type associated with a file.
+
+```js
+mime.lookupAll('json')             // ['application/json']
+mime.lookupAll('.rtf')             // ['application/rtf', 'text/rtf']
+mime.lookupAll('file.bmp')         // ['image/bmp', 'image/x-ms-bmp']
+mime.lookupAll('folder/file.js')   // ['application/javascript']
+mime.lookupAll('folder/.htaccess') // []
+
+mime.lookupAll('cats')             // []
+mime.lookupAll(42)                 // false
+```
+
 ### mime.contentType(type)
 
 Create a full content-type header given a content-type or extension.

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var extname = require('path').extname
 
 var extractTypeRegExp = /^\s*([^;\s]*)(?:;|\s|$)/
 var textTypeRegExp = /^text\//i
+var typeSets = {}
 
 /**
  * Module exports.
@@ -34,10 +35,14 @@ exports.contentType = contentType
 exports.extension = extension
 exports.extensions = Object.create(null)
 exports.lookup = lookup
+exports.lookupAll = lookupAll
 exports.types = Object.create(null)
 
 // Populate the extensions/types maps
 populateMaps(exports.extensions, exports.types)
+
+// Populate the extensions->[types] set
+populateTypeSets(typeSets)
 
 /**
  * Get the default charset for a MIME type.
@@ -123,13 +128,16 @@ function extension (type) {
 }
 
 /**
- * Lookup the MIME type for a file path/extension.
- *
+ * Obtain the extension of a filename or filepath.
+ * If the path is not a string or a proper extension isn't found,
+ *   false is returned.
+ * The path is case insensitive (so hello.html and HELLO.HTML are equal).
+ * 
  * @param {string} path
- * @return {boolean|string}
+ * @return {boolean|string} the file extension if available. false otherwise.
  */
 
-function lookup (path) {
+function extractExtension (path) {
   if (!path || typeof path !== 'string') {
     return false
   }
@@ -143,8 +151,43 @@ function lookup (path) {
     return false
   }
 
+  return extension
+}
+
+/**
+ * Lookup the MIME type for a file path/extension.
+ *
+ * @param {string} path
+ * @return {boolean|string}
+ */
+
+function lookup (path) {
+  var extension = extractExtension(path)
+
+  if (!extension) {
+    return false
+  }
+
   return exports.types[extension] || false
 }
+
+/**
+ * Find all MIME types that are associated with a file extensions.
+ *
+ * @param {string} path or file extension
+ * @return {boolean|array<string>}
+ */
+
+function lookupAll (path) {
+  var extension = extractExtension(path)
+
+  if (!extension) {
+    return false
+  }
+
+  return typeSets[extension] || []
+}
+
 
 /**
  * Populate the extensions and types maps.
@@ -184,5 +227,31 @@ function populateMaps (extensions, types) {
       // set the extension -> mime
       types[extension] = type
     }
+  })
+}
+
+/**
+ * Populate the set where extension->[types]
+ * An example is .rtf -> ['application/rtf', 'text/rtf']
+ *
+ * @private
+ * @param {object<string, array<string>>} the map to fill in
+ */
+
+function populateTypeSets (typeSets) {
+  Object.keys(db).forEach(function (type) {
+    var exts = db[type].extensions
+
+    if (!exts || !exts.length) {
+      return
+    }
+
+    exts.forEach(function (ext) {
+      if (typeSets[ext]) {
+        typeSets[ext].push(type)
+      } else {
+        typeSets[ext] = [type]
+      }
+    })
   })
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eslint-plugin-promise": "3.5.0",
     "eslint-plugin-standard": "2.1.1",
     "istanbul": "0.4.5",
-    "mocha": "1.21.5"
+    "mocha": "1.21.5",
+    "nodemon": "^1.11.0"
   },
   "files": [
     "HISTORY.md",
@@ -35,6 +36,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --reporter spec test/test.js",
+    "test:watch": "nodemon --exec npm test",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/test.js",
     "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot test/test.js"
   }

--- a/test/test.js
+++ b/test/test.js
@@ -224,4 +224,77 @@ describe('mimeTypes', function () {
       })
     })
   })
+
+  describe('.lookupAll(extension)', function () {
+    it('should return a list with multiple mime types when many exist', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('.rtf'), ['application/rtf', 'text/rtf'])
+    })
+
+    it('should return a list with one mime type when only one exists', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('.html'), ['text/html'])
+    })
+
+    it('should work without a leading dot', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('rtf'), ['application/rtf', 'text/rtf'])
+    })
+
+    it('should be case-insensitive', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('RtF'), ['application/rtf', 'text/rtf'])
+      assert.deepStrictEqual(mimeTypes.lookupAll('.HTML'), ['text/html'])
+    })
+
+    it('should return an empty list for an unknown extension', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('bogus'), [])
+    })
+
+    it('should return false for non-strings', function () {
+      assert.strictEqual(mimeTypes.lookupAll(null), false)
+      assert.strictEqual(mimeTypes.lookupAll(undefined), false)
+      assert.strictEqual(mimeTypes.lookupAll(3.141592), false)
+      assert.strictEqual(mimeTypes.lookupAll({}), false)
+    })
+  })
+
+  describe('.lookupAll(path)', function () {
+    it('should return mime type for file name', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('page.html'), ['text/html'])
+    })
+
+    it('should return mime type for relative path', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('path/to/page.html'), ['text/html'])
+      assert.deepStrictEqual(mimeTypes.lookupAll('path\\to\\doc.rtf'), ['application/rtf', 'text/rtf'])
+    })
+
+    it('should return mime type for absolute path', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('/path/to/page.html'), ['text/html'])
+      assert.deepStrictEqual(mimeTypes.lookupAll('C:\\path\\to\\doc.rtf'), ['application/rtf', 'text/rtf'])
+    })
+
+    it('should be case insensitive', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('/path/to/PAGE.HTML'), ['text/html'])
+      assert.deepStrictEqual(mimeTypes.lookupAll('C:\\path\\to\\DOC.RTF'), ['application/rtf', 'text/rtf'])
+    })
+
+    it('should return an empty list for unknown extension', function () {
+      assert.deepStrictEqual(mimeTypes.lookupAll('/path/to/file.bogus'), [])
+    })
+
+    it('should return false for path without extension', function () {
+      assert.strictEqual(mimeTypes.lookupAll('/path/to/json'), false)
+    })
+
+    describe('lookupAll() - path with dotfile', function () {
+      it('should return false when extension-less', function () {
+        assert.strictEqual(mimeTypes.lookupAll('/path/to/.json'), false)
+      })
+
+      it('should return all mime types when there is extension', function () {
+        assert.deepStrictEqual(mimeTypes.lookupAll('/path/to/.config.json'), ['application/json'])
+      })
+
+      it('should return all mime types when there is extension, but no path', function () {
+        assert.deepStrictEqual(mimeTypes.lookupAll('.config.json'), ['application/json'])
+      })
+    })
+  })
 })


### PR DESCRIPTION
This is to address https://github.com/jshttp/mime-types/issues/23. The goal of this PR is add a function for looking up all MIME types associated to a file extension. 

This would be useful for me to be able to create sets of acceptable MIME types for file validations without having to manually look up each potential MIME type with it. This happens to come up in a few examples (including `bmp`, `rtf`, and `mp3` to name a few). 

I also included a little test watcher script to help while working on the feature. I'd be glad to remove that if it's undesired though.

Hoping to have a conversation about what's good or not. I thought an initial implementation would be a good starting point.

Thanks for your work on this module!