### PR TITLE
Bump up mime-db version to 1.29.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,13 @@
+unreleased
+==========
+
+  * deps: mime-db@~1.29.0
+    - Add new mime types
+    - Add `application/fido.trusted-apps+json`
+    - Add extension `.wadl` to `application/vnd.sun.wadl+xml`
+    - Add extension `.gz` to `application/gzip`
+    - Update extensions `.md` and `.markdown` to be `text/markdown`
+
 2.1.15 / 2017-03-23
 ===================
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": "jshttp/mime-types",
   "dependencies": {
-    "mime-db": "~1.27.0"
+    "mime-db": "~1.29.0"
   },
   "devDependencies": {
     "eslint": "3.18.0",


### PR DESCRIPTION
This PR bumps up `mime-db` version to `~1.29.0`. I've tried to follow the conventions I noticed on previous commits on HISTORY.md, let me know if you'd like to merge this.

Closes #37