### PR TITLE
#79 bump version of mime-db to 1.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": "jshttp/mime-types",
   "dependencies": {
-    "mime-db": "1.44.0"
+    "mime-db": "1.45.0"
   },
   "devDependencies": {
     "eslint": "7.2.0",


### PR DESCRIPTION
as requested in #79 using the latest mime-db package will [add support for new mime types](https://github.com/jshttp/mime-db/blob/master/HISTORY.md)