### PR TITLE
docs: fix capitalization of proper noun JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status][ci-image]][ci-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
 
-The ultimate javascript content-type utility.
+The ultimate JavaScript content-type utility.
 
 Similar to [the `mime@1.x` module](https://www.npmjs.com/package/mime), except:
 


### PR DESCRIPTION
## Changes:

- Change word `javascript` -> `JavaScript`

## Context:

JavaScript is a proper noun and should be capitalized properly.
