### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function lookup (path) {
   // get the extension ("ext" or ".ext" or full path)
   var extension = extname('x.' + path)
     .toLowerCase()
-    .substr(1)
+    .slice(1)
 
   if (!extension) {
     return false
@@ -175,7 +175,7 @@ function populateMaps (extensions, types) {
         var to = preference.indexOf(mime.source)
 
         if (types[extension] !== 'application/octet-stream' &&
-          (from > to || (from === to && types[extension].substr(0, 12) === 'application/'))) {
+          (from > to || (from === to && types[extension].slice(0, 12) === 'application/'))) {
           // skip the remapping
           continue
         }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.