### PR TITLE
fix: add "path" to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": "jshttp/mime-types",
   "dependencies": {
-    "mime-db": "1.52.0"
+    "mime-db": "1.52.0",
+    "path": "0.12.7"
   },
   "devDependencies": {
     "eslint": "7.32.0",


### PR DESCRIPTION
Or maybe to peer dependencies?

In any case, `path` is not always available when using this package in a frontend environment and throws errors if it is missing.