### PR TITLE
Fix: lookup JSDoc typings

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function charset (type) {
  * Create a full Content-Type header given a MIME type or extension.
  *
  * @param {string} str
- * @return {boolean|string}
+ * @return {false|string}
  */
 
 function contentType (str) {
@@ -126,7 +126,7 @@ function extension (type) {
  * Lookup the MIME type for a file path/extension.
  *
  * @param {string} path
- * @return {boolean|string}
+ * @return {false |string}
  */
 
 function lookup (path) {


### PR DESCRIPTION
This is a quick fix to two functions which, since their detection failure returns false, have their return values annotated as `{boolean|string}`.  In reality, the boolean returned is _always_ `false`, and so it makes more sense to use a JSDoc type expression of `false`.

> Sure. But why does this really matter?

With the return type as boolean i.e. `{true|false}`
a usage with a short circuit assignment to a `{string}` var will cause a false positive type warning:
```js
const headers = {
  ⋮
  contentType: mime.lookup(path.extname(filePath)) || 'text/plain;charset=UTF-8',
}
```
as the language server infers from the `{boolean|string}` type annotation(s) that `lookup` will in some scenarios return true, which would make `contentType` no longer a `{string}`.