### PR TITLE
v3: Remove node  < 18 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,27 +10,12 @@ jobs:
     strategy:
       matrix:
         name:
-        - io.js 1.x
-        - io.js 2.x
-        - io.js 3.x
         - Node.js 16.x
         - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
 
         include:
-        - name: io.js 1.x
-          node-version: "1.8"
-          npm-i: mocha@3.5.3 nyc@10.3.2
-
-        - name: io.js 2.x
-          node-version: "2.5"
-          npm-i: mocha@3.5.3 nyc@10.3.2
-
-        - name: io.js 3.x
-          node-version: "3.3"
-          npm-i: mocha@3.5.3 nyc@10.3.2
-
         - name: Node.js 16.x
           node-version: "16.19"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,34 +10,30 @@ jobs:
     strategy:
       matrix:
         name:
-        - Node.js 16.x
-        - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
         - Node.js 20.x
         - Node.js 21.x
+        - Node.js 22.x
 
         include:
-        - name: Node.js 16.x
-          node-version: "16.19"
-
-        - name: Node.js 17.x
-          node-version: "17.9"
-
         - name: Node.js 18.x
-          node-version: "18.14"
+          node-version: "18"
 
         - name: Node.js 19.x
-          node-version: "19.6"
+          node-version: "19"
 
         - name: Node.js 20.x
-          node-version: "20.10"
+          node-version: "20"
 
         - name: Node.js 21.x
-          node-version: "21.4"
+          node-version: "21"
+
+        - name: Node.js 22.x
+          node-version: "22"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,49 +10,15 @@ jobs:
     strategy:
       matrix:
         name:
-        - Node.js 0.6
-        - Node.js 0.8
-        - Node.js 0.10
-        - Node.js 0.12
         - io.js 1.x
         - io.js 2.x
         - io.js 3.x
-        - Node.js 4.x
-        - Node.js 5.x
-        - Node.js 6.x
-        - Node.js 7.x
-        - Node.js 8.x
-        - Node.js 9.x
-        - Node.js 10.x
-        - Node.js 11.x
-        - Node.js 12.x
-        - Node.js 13.x
-        - Node.js 14.x
-        - Node.js 15.x
         - Node.js 16.x
         - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
 
         include:
-        - name: Node.js 0.6
-          node-version: "0.6"
-          npm-i: mocha@1.21.5
-          npm-rm: nyc
-
-        - name: Node.js 0.8
-          node-version: "0.8"
-          npm-i: mocha@2.5.3
-          npm-rm: nyc
-
-        - name: Node.js 0.10
-          node-version: "0.10"
-          npm-i: mocha@3.5.3 nyc@10.3.2
-
-        - name: Node.js 0.12
-          node-version: "0.12"
-          npm-i: mocha@3.5.3 nyc@10.3.2
-
         - name: io.js 1.x
           node-version: "1.8"
           npm-i: mocha@3.5.3 nyc@10.3.2
@@ -64,52 +30,6 @@ jobs:
         - name: io.js 3.x
           node-version: "3.3"
           npm-i: mocha@3.5.3 nyc@10.3.2
-
-        - name: Node.js 4.x
-          node-version: "4.9"
-          npm-i: mocha@5.2.0 nyc@11.9.0
-
-        - name: Node.js 5.x
-          node-version: "5.12"
-          npm-i: mocha@5.2.0 nyc@11.9.0
-
-        - name: Node.js 6.x
-          node-version: "6.17"
-          npm-i: mocha@6.2.2 nyc@14.1.1
-
-        - name: Node.js 7.x
-          node-version: "7.10"
-          npm-i: mocha@6.2.2 nyc@14.1.1
-
-        - name: Node.js 8.x
-          node-version: "8.17"
-          npm-i: mocha@7.2.0 nyc@14.1.1
-
-        - name: Node.js 9.x
-          node-version: "9.11"
-          npm-i: mocha@7.2.0 nyc@14.1.1
-
-        - name: Node.js 10.x
-          node-version: "10.24"
-          npm-i: mocha@8.4.0
-
-        - name: Node.js 11.x
-          node-version: "11.15"
-          npm-i: mocha@8.4.0
-
-        - name: Node.js 12.x
-          node-version: "12.22"
-          npm-i: mocha@9.2.2
-
-        - name: Node.js 13.x
-          node-version: "13.14"
-          npm-i: mocha@9.2.2
-
-        - name: Node.js 14.x
-          node-version: "14.21"
-
-        - name: Node.js 15.x
-          node-version: "15.14"
 
         - name: Node.js 16.x
           node-version: "16.19"
@@ -129,26 +49,7 @@ jobs:
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
       run: |
-        if [[ "${{ matrix.node-version }}" == 0.6* ]]; then
-          sudo sh -c 'echo "deb http://us.archive.ubuntu.com/ubuntu/ bionic universe" >> /etc/apt/sources.list'
-          sudo sh -c 'echo "deb http://security.ubuntu.com/ubuntu bionic-security main" >> /etc/apt/sources.list'
-          sudo apt-get update
-          sudo apt-get install g++-4.8 gcc-4.8 libssl1.0-dev python2 python-is-python2
-          export CC=/usr/bin/gcc-4.8
-          export CXX=/usr/bin/g++-4.8
-        fi
         nvm install --default ${{ matrix.node-version }}
-        if [[ "${{ matrix.node-version }}" == 0.* && "$(cut -d. -f2 <<< "${{ matrix.node-version }}")" -lt 10 ]]; then
-          nvm install --alias=npm 0.10
-          nvm use ${{ matrix.node-version }}
-          if [[ "$(npm -v)" == 1.1.* ]]; then
-            nvm exec npm npm install -g npm@1.1
-            ln -fs "$(which npm)" "$(dirname "$(nvm which npm)")/npm"
-          else
-            sed -i '1s;^.*$;'"$(printf '#!%q' "$(nvm which npm)")"';' "$(readlink -f "$(which npm)")"
-          fi
-          npm config set strict-ssl false
-        fi
         dirname "$(nvm which ${{ matrix.node-version }})" >> "$GITHUB_PATH"
 
     - name: Configure npm
@@ -166,18 +67,6 @@ jobs:
     - name: Install npm module(s) ${{ matrix.npm-i }}
       run: npm install --save-dev ${{ matrix.npm-i }}
       if: matrix.npm-i != ''
-
-    - name: Setup Node.js version-specific dependencies
-      shell: bash
-      run: |
-        # eslint for linting
-        # - remove on Node.js < 12
-        if [[ "$(cut -d. -f1 <<< "${{ matrix.node-version }}")" -lt 12 ]]; then
-          node -pe 'Object.keys(require("./package").devDependencies).join("\n")' | \
-            grep -E '^eslint(-|$)' | \
-            sort -r | \
-            xargs -n1 npm rm --silent --save-dev
-        fi
 
     - name: Install Node.js dependencies
       run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
+        - Node.js 20.x
+        - Node.js 21.x
 
         include:
         - name: Node.js 16.x
@@ -27,6 +29,12 @@ jobs:
 
         - name: Node.js 19.x
           node-version: "19.6"
+
+        - name: Node.js 20.x
+          node-version: "20.10"
+
+        - name: Node.js 21.x
+          node-version: "21.4"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Putting this up so we have something to look at for #115.  Cutoff does not have to be at node@16.  That's just where we'd draw the line in the world of `uuid`.

Maybe create a v3 branch / milestone for this and the `peerDependency` change (if/when that happens), and the mime-score PR (coming soon)?