### PR TITLE
Fix Node 8 and 9 tests, pin nyc version used for testing in Node 9 and 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 9.x
           node-version: "9.11"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 10.x
           node-version: "10.24"


### PR DESCRIPTION
closes #122 
Same fix as https://github.com/jshttp/http-errors/pull/109

Still dunno root cause exactly, but It's likely just Node version requirements shifted for the nyc version we are using