### PR TITLE
fix: mime-db@1.53.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ This is a [Node.js](https://nodejs.org/en/) module available through the
 $ npm install mime-types
 ```
 
+## Note on MIME Type Data and Semver
+
+This package considers the programmatic api as the semver compatibility. Additionally, the package which provides the MIME data
+for this package (`mime-db`) *also* considers it's programmatic api as the semver contract. This means the MIME type resolution is *not* considered
+in the semver bumps.
+
+In the past the version of `mime-db` was pinned to give two decision points when adopting MIME data changes. This is no longer true. We still update the
+`mime-db` package here as a `minor` release when necessary, but will use a `^` range going forward. This means that if you want to pin your `mime-db` data
+you will need to do it in your application. While this expectation was not set in docs until now, it is how the pacakge operated, so we do not feel this is
+a breaking change.
+
+If you wish to pin your `mime-db` version you can do that with overrides via your package manager of choice. See their documentation for how to correctly configure that.
+
 ## Adding Types
 
 All mime types are based on [mime-db](https://www.npmjs.com/package/mime-db),

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": "jshttp/mime-types",
   "dependencies": {
-    "mime-db": "1.52.0"
+    "mime-db": "^1.53.0"
   },
   "devDependencies": {
     "eslint": "8.33.0",

--- a/test/test.js
+++ b/test/test.js
@@ -140,7 +140,7 @@ describe('mimeTypes', function () {
     })
 
     it('should return mime type for ".js"', function () {
-      assert.strictEqual(mimeTypes.lookup('.js'), 'application/javascript')
+      assert.strictEqual(mimeTypes.lookup('.js'), 'text/javascript')
     })
 
     it('should return mime type for ".json"', function () {


### PR DESCRIPTION
Updates mime-db which included an update to `.js` mapping to the correctly specified `text/javascript` mime type. This broke a test and is likely to be generally disruptive, but I believe that this should be considered non-breaking from a semver perspective since it is to spec. Please tell me why I am wrong before we release this 🤣.

EDIT: Copying this comment here so folks understand that I am both saying this from my opinion as well as precidence for this package's history.

https://github.com/jshttp/mime-types/issues/110#issuecomment-1848576753

> Yes, this pins so there are two decision points. The semver is tricky bc typically in both packages, the data is has not been considered in the semver, as the way in which data changes in fluid with standards and browsers and there can be a lot of changes. Usually only the javascript api of the module has been considered in whay type of semver bump it would be.

And note: I removed the pin with this commit. That is up for debate, but I do believe that unless we can get more maintainers around to help with this stuff we plan to optimize for our ability to more quickly ship change in the future, including loosening version ranges like this.

Second edit: I will fix the CI error which is likely because npm that long ago didn't support `^` ranges, but I dont want to waste time until we get good agreement on switching to a range in the first place.