### PR TITLE
fix: mime-score logic for mp4 types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         name:

--- a/mimeScore.js
+++ b/mimeScore.js
@@ -25,6 +25,11 @@ var TYPE_SCORES = {
   // prefer font/woff over application/font-woff
   font: 2,
 
+  // prefer video/mp4 over audio/mp4 over over application/mp4
+  // See https://www.rfc-editor.org/rfc/rfc4337.html#section-2
+  audio: 2,
+  video: 3,
+
   default: 0
 }
 

--- a/mimeScore.js
+++ b/mimeScore.js
@@ -25,7 +25,7 @@ var TYPE_SCORES = {
   // prefer font/woff over application/font-woff
   font: 2,
 
-  // prefer video/mp4 over audio/mp4 over over application/mp4
+  // prefer video/mp4 over audio/mp4 over application/mp4
   // See https://www.rfc-editor.org/rfc/rfc4337.html#section-2
   audio: 2,
   video: 3,

--- a/test/test.js
+++ b/test/test.js
@@ -158,6 +158,10 @@ describe('mimeTypes', function () {
       assert.strictEqual(mimeTypes.lookup('.xml'), 'application/xml')
     })
 
+    it('should return mime type for ".mp4"', function () {
+      assert.strictEqual(mimeTypes.lookup('.mp4'), 'video/mp4')
+    })
+
     it('should work without the leading dot', function () {
       assert.strictEqual(mimeTypes.lookup('html'), 'text/html')
       assert.strictEqual(mimeTypes.lookup('xml'), 'application/xml')


### PR DESCRIPTION
fixes #138

Note: CI checks were [failing](https://github.com/jshttp/mime-types/actions/runs/14807359604) due to `ubunto-20.04` runners no longer being supported.  Updated `ci.yml` to use `ubuntu-latest`.