### PR TITLE
Backport mime-db@1.54.0 into v2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+  * deps: mime-db@1.54.0
+    - Add new upstream MIME types
+
 2.1.35 / 2022-03-12
 ===================
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": "jshttp/mime-types",
   "dependencies": {
-    "mime-db": "1.52.0"
+    "mime-db": "1.54.0"
   },
   "devDependencies": {
     "eslint": "8.33.0",

--- a/test/test.js
+++ b/test/test.js
@@ -140,7 +140,7 @@ describe('mimeTypes', function () {
     })
 
     it('should return mime type for ".js"', function () {
-      assert.strictEqual(mimeTypes.lookup('.js'), 'application/javascript')
+      assert.strictEqual(mimeTypes.lookup('.js'), 'text/javascript')
     })
 
     it('should return mime type for ".json"', function () {


### PR DESCRIPTION
Backport mime-db@1.54.0 into mime-types v2 to help [form-data](https://github.com/form-data) to support `*.mjs` files https://github.com/form-data/form-data/pull/581