### PR TITLE
fix: _preferredTypeLegacy was broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,10 +199,10 @@ function _preferredTypeLegacy (ext, type0, type1) {
   var score1 = type1 ? SOURCE_RANK.indexOf(db[type1].source) : 0
 
   if (
-    exports.types[extension] !== 'application/octet-stream' &&
+    exports.types[ext] !== 'application/octet-stream' &&
     (score0 > score1 ||
       (score0 === score1 &&
-        exports.types[extension]?.slice(0, 12) === 'application/'))
+        exports.types[ext]?.slice(0, 12) === 'application/'))
   ) {
     return type0
   }


### PR DESCRIPTION
This method was introduced in https://github.com/jshttp/mime-types/commit/541f9c57b3e418fc449fa84be4a69a1e1a7835db and was never correct

I guess this can be just removed?